### PR TITLE
Full description not short description is used by the Blazor app

### DIFF
--- a/PocketDDD.Server/PocketDDD.Server.Services/SessionizeService.cs
+++ b/PocketDDD.Server/PocketDDD.Server.Services/SessionizeService.cs
@@ -88,13 +88,13 @@ public class SessionizeService
                     SessionizeId = item.id,
                     EventDetail = dbEvent,
                     SpeakerToken = Guid.NewGuid(),
-                    FullDescription = ""
+                    ShortDescription = ""
                 };
                 dbContext.Sessions.Add(dbSession);
             }
 
             dbSession.Title = item.title;
-            dbSession.ShortDescription = item.description;
+            dbSession.FullDescription = item.description;
             dbSession.Speaker = GetSpeakers(speakers, item.speakers);
             dbSession.Track = dbTracks.Single(x => x.SessionizeId == item.roomId);
             dbSession.TimeSlot = GetTimeSlot(dbTimeSlots, item.startsAt, item.endsAt);


### PR DESCRIPTION
Sessionize only provides one type of description - use this in the app! We should look to remove the `ShortDescription` column in the future, but not this close to the event!