### PR TITLE
Remove Track name from UI

### DIFF
--- a/PocketDDD.BlazorClient/PocketDDD.BlazorClient/Features/Home/Components/EventData.razor
+++ b/PocketDDD.BlazorClient/PocketDDD.BlazorClient/Features/Home/Components/EventData.razor
@@ -31,7 +31,7 @@
                         @sessionItem.session.Title
                     </MudText>
                     <MudText Typo="Typo.subtitle2">@sessionItem.session.SpeakerName</MudText>
-                    <MudText Typo="Typo.subtitle2">@sessionItem.session.TrackName (@sessionItem.session.RoomName)</MudText>
+                    <MudText Typo="Typo.subtitle2">@sessionItem.session.RoomName</MudText>
                 </MudPaper>
             </MudListItem>
 

--- a/PocketDDD.BlazorClient/PocketDDD.BlazorClient/Features/Session/Components/Session.razor
+++ b/PocketDDD.BlazorClient/PocketDDD.BlazorClient/Features/Session/Components/Session.razor
@@ -15,8 +15,7 @@
 {
     <MudText Typo="Typo.h5" Class="ma-2">
         @State.Value.Session.From.ToString("h:mm")
-        @State.Value.Session.From.ToString("tt").ToLowerInvariant(), 
-        @State.Value.Session.TrackName 
+        @State.Value.Session.From.ToString("tt").ToLowerInvariant()
     </MudText>
 
     <MudText Typo="Typo.subtitle1" Class="ma-2">


### PR DESCRIPTION
In 2024 we added the track name to the room name in sessionize, this meant that we didn't need the track name specifically in the UI