### PR TITLE
Auto update from sessionize

### DIFF
--- a/PocketDDD.BlazorClient/PocketDDD.BlazorClient/Services/FakePocketDDDApiService.cs
+++ b/PocketDDD.BlazorClient/PocketDDD.BlazorClient/Services/FakePocketDDDApiService.cs
@@ -25,6 +25,7 @@ public class FakePocketDDDApiService : IPocketDDDApiService
         return
             new EventDataResponseDTO
             {
+                Id = 1,
                 Version = 1,
                 TimeSlots = new[]
                 {

--- a/PocketDDD.BlazorClient/PocketDDD.BlazorClient/Services/FakePocketDDDApiService.cs
+++ b/PocketDDD.BlazorClient/PocketDDD.BlazorClient/Services/FakePocketDDDApiService.cs
@@ -26,7 +26,7 @@ public class FakePocketDDDApiService : IPocketDDDApiService
             new EventDataResponseDTO
             {
                 Id = 1,
-                Version = 1,
+                Version = 0, //Set to 0 so if we ever connect this to a real API then it will update!
                 TimeSlots = new[]
                 {
                     new TimeSlotDTO

--- a/PocketDDD.Server/PocketDDD.Server.DB/Migrations/2025_SeedData.sql
+++ b/PocketDDD.Server/PocketDDD.Server.DB/Migrations/2025_SeedData.sql
@@ -8,18 +8,6 @@ delete TimeSlots
 delete Tracks
 delete EventDetail
 
-
-GO
-
--- Reset the identity columns
-DBCC CHECKIDENT ('[Tracks]', RESEED, 0);
-DBCC CHECKIDENT ('[TimeSlots]', RESEED, 0);
-DBCC CHECKIDENT ('[Sessions]', RESEED, 0);
-
--- There is hardcoding to EventDetail ID 1 so we reset to 1 not 0
-DBCC CHECKIDENT ('[EventDetail]', RESEED, 1); -- Use if this is a brand new table that has never been used before
---DBCC CHECKIDENT ('[EventDetail]', RESEED, 0); -- Use if this is an empty table that used to have rows
-
 GO
 
 -- Add 2025 Sessionize ID

--- a/PocketDDD.Server/PocketDDD.Server.Services/EventDataService.cs
+++ b/PocketDDD.Server/PocketDDD.Server.Services/EventDataService.cs
@@ -1,63 +1,79 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using PocketDDD.Server.DB;
-using PocketDDD.Server.Model.DTOs;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using PocketDDD.Shared.API.RequestDTOs;
 using PocketDDD.Shared.API.ResponseDTOs;
 
 namespace PocketDDD.Server.Services;
-public class EventDataService
-{
-    private readonly PocketDDDContext dbContext;
 
-    public EventDataService(PocketDDDContext dbContext)
+public class EventDataService(PocketDDDContext dbContext, IMemoryCache memoryCache, ILogger<EventDataService> logger)
+{
+    private const string FetchLatestEventDataCacheKey = nameof(FetchLatestEventData);
+    private const string FetchCurrentEventDetailIdCacheKey = nameof(FetchCurrentEventDetailId);
+
+    public async Task<int> FetchCurrentEventDetailId()
     {
-        this.dbContext = dbContext;
+        if (memoryCache.TryGetValue<int?>(FetchCurrentEventDetailIdCacheKey, out var cachedEventDetailId))
+            return cachedEventDetailId!.Value;
+
+        cachedEventDetailId = await dbContext.EventDetail.MaxAsync(e => e.Id);
+        memoryCache.Set(FetchCurrentEventDetailIdCacheKey, cachedEventDetailId, TimeSpan.FromMinutes(5));
+
+        return cachedEventDetailId.Value;
     }
 
-    public async Task<EventDataResponseDTO?> FetchLatestEventData(EventDataUpdateRequestDTO requestDTO)
+    public async Task<EventDataResponseDTO?> FetchLatestEventData(EventDataUpdateRequestDTO requestDto)
     {
-        var eventDetails = await dbContext.EventDetail
-                                          .Include(x => x.TimeSlots)
-                                          .Include(x => x.Tracks)
-                                          .Include(x => x.Sessions)
-                                          .SingleAsync(x => x.Id == 1);
-            
-        if (requestDTO.Version == eventDetails!.Version)
+        var currentEventDetailId = await FetchCurrentEventDetailId();
+        
+        if (memoryCache.TryGetValue<EventDataResponseDTO?>(FetchLatestEventDataCacheKey, out var latestEventData))
+        {
+            logger.LogDebug("Retrieved latest event data from the cache {eventData}", latestEventData);
+        }
+        else
+        {
+            logger.LogDebug("No event data in the cache, retrieving from the db");
+            latestEventData = await dbContext.EventDetail
+                .AsNoTracking()
+                .AsSingleQuery()
+                .Select(eventDetails => new EventDataResponseDTO
+                {
+                    Id = eventDetails.Id,
+                    Version = eventDetails.Version,
+                    TimeSlots = eventDetails.TimeSlots.Select(ts => new TimeSlotDTO
+                    {
+                        Id = ts.Id,
+                        Info = ts.Info,
+                        From = ts.From,
+                        To = ts.To
+                    }).ToList(),
+                    Tracks = eventDetails.Tracks.Select(t => new TrackDTO
+                    {
+                        Id = t.Id,
+                        Name = t.Name,
+                        RoomName = t.RoomName
+                    }).ToList(),
+                    Sessions = eventDetails.Sessions.Select(s => new SessionDTO
+                    {
+                        Id = s.Id,
+                        Title = s.Title,
+                        ShortDescription = s.ShortDescription,
+                        FullDescription = s.FullDescription,
+                        Speaker = s.Speaker,
+                        TimeSlotId = s.TimeSlot.Id,
+                        TrackId = s.Track.Id
+                    }).ToList()
+                })
+                .SingleAsync(e => e.Id == currentEventDetailId);
+
+            memoryCache.Set(FetchLatestEventDataCacheKey, latestEventData, TimeSpan.FromMinutes(5));
+            logger.LogDebug("Updated the latest event data in the cache {eventData}", latestEventData);
+        }
+
+        if (requestDto.Version >= latestEventData!.Version)
             return null;
 
-        var dtoResponse = new EventDataResponseDTO
-        {
-            Version = eventDetails.Version,
-            TimeSlots = eventDetails.TimeSlots.Select(ts => new TimeSlotDTO
-            {
-                Id = ts.Id,
-                Info = ts.Info,
-                From = ts.From,
-                To = ts.To
-            }).ToList(),
-            Tracks = eventDetails.Tracks.Select(t => new TrackDTO
-            {
-                Id = t.Id,
-                Name = t.Name,
-                RoomName = t.RoomName
-            }).ToList(),
-            Sessions = eventDetails.Sessions.Select(s => new SessionDTO
-            {
-                Id = s.Id,
-                Title = s.Title,
-                ShortDescription = s.ShortDescription,
-                FullDescription = s.FullDescription,
-                Speaker = s.Speaker,
-                TimeSlotId = s.TimeSlot.Id,
-                TrackId = s.Track.Id
-            }).ToList()
-        };
-
-        return dtoResponse;
+        return latestEventData;
     }
 }

--- a/PocketDDD.Server/PocketDDD.Server.Services/RegistrationService.cs
+++ b/PocketDDD.Server/PocketDDD.Server.Services/RegistrationService.cs
@@ -1,30 +1,20 @@
-﻿using PocketDDD.Server.DB;
+﻿using System.Security.Cryptography;
+using PocketDDD.Server.DB;
 using PocketDDD.Server.Model.DBModel;
-using PocketDDD.Server.Model.DTOs;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
-using System.Threading.Tasks;
 using PocketDDD.Shared.API.RequestDTOs;
 using PocketDDD.Shared.API.ResponseDTOs;
 
 namespace PocketDDD.Server.Services;
-public class RegistrationService
+
+public class RegistrationService(PocketDDDContext dbContext, EventDataService eventDataService)
 {
-    private readonly PocketDDDContext dbContext;
-
-    public RegistrationService(PocketDDDContext dbContext)
-    {
-        this.dbContext = dbContext;
-    }
-
     public async Task<LoginResultDTO> Register(RegisterDTO dto)
     {
+        var currentEventDetailId = await eventDataService.FetchCurrentEventDetailId();
+
         var user = new User
         {
-            EventDetailId = 1,
+            EventDetailId = currentEventDetailId,
             Name = dto.Name,
             Token = GenerateBearerToken(),
             EventScore = 1

--- a/PocketDDD.Server/PocketDDD.Server.Services/SessionizeService.cs
+++ b/PocketDDD.Server/PocketDDD.Server.Services/SessionizeService.cs
@@ -60,6 +60,7 @@ public class SessionizeService
 
         if (dbContext.ChangeTracker.HasChanges())
         {
+            dbEvent.Version++;
             Logger.LogInformation("Updating db with changes to rooms");
             await dbContext.SaveChangesAsync();
         }
@@ -67,7 +68,7 @@ public class SessionizeService
         {
             Logger.LogInformation("No changes to rooms were detected");
         }
-        
+
         Logger.LogInformation("Looking for changes to time slots and breaks");
 
         var dbTimeSlots = await dbContext.TimeSlots.ToListAsync();
@@ -93,8 +94,10 @@ public class SessionizeService
 
             dbTimeSlot.Info = item.isServiceSession ? item.serviceSessionDetails : null;
         }
+
         if (dbContext.ChangeTracker.HasChanges())
         {
+            dbEvent.Version++;
             Logger.LogInformation("Updating db with changes to time slots and breaks");
             await dbContext.SaveChangesAsync();
         }
@@ -135,8 +138,10 @@ public class SessionizeService
             dbSession.Track = dbTracks.Single(x => x.SessionizeId == item.roomId);
             dbSession.TimeSlot = GetTimeSlot(dbTimeSlots, item.startsAt, item.endsAt);
         }
+
         if (dbContext.ChangeTracker.HasChanges())
         {
+            dbEvent.Version++;
             Logger.LogInformation("Updating db with changes to sessions");
             await dbContext.SaveChangesAsync();
         }

--- a/PocketDDD.Server/PocketDDD.Server.Services/SessionizeService.cs
+++ b/PocketDDD.Server/PocketDDD.Server.Services/SessionizeService.cs
@@ -86,11 +86,12 @@ public class SessionizeService
                 {
                     EventDetail = dbEvent,
                     From = item.startsAt,
-                    To = item.endsAt,
-                    Info = item.isServiceSession ? item.serviceSessionDetails : null
+                    To = item.endsAt
                 };
                 dbContext.TimeSlots.Add(dbTimeSlot);
             }
+
+            dbTimeSlot.Info = item.isServiceSession ? item.serviceSessionDetails : null;
         }
         if (dbContext.ChangeTracker.HasChanges())
         {

--- a/PocketDDD.Server/PocketDDD.Server.WebAPI/Program.cs
+++ b/PocketDDD.Server/PocketDDD.Server.WebAPI/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using PocketDDD.Server.DB;
 using PocketDDD.Server.Services;
+using PocketDDD.Server.WebAPI;
 using PocketDDD.Server.WebAPI.Authentication;
 
 var corsPolicy = "corsPolicy";
@@ -36,6 +37,8 @@ builder.Services.AddScoped<PrizeDrawService>();
 builder.Services.AddScoped<SpeakersService>();
 
 builder.Services.AddHttpClient<SessionizeService>();
+
+builder.Services.AddHostedService<UpdateFromSessionizeBackgroundService>();
 
 builder.Services.AddAuthentication()
     .AddScheme<UserIsRegisteredOptions, UserIsRegisteredAuthHandler>(UserIsRegisteredAuthHandler.SchemeName, null);

--- a/PocketDDD.Server/PocketDDD.Server.WebAPI/Program.cs
+++ b/PocketDDD.Server/PocketDDD.Server.WebAPI/Program.cs
@@ -29,6 +29,8 @@ builder.Services.AddDbContext<PocketDDDContext>(
     options => options.UseSqlServer("name=ConnectionStrings:PocketDDDContext")
 );
 
+builder.Services.AddMemoryCache();
+
 builder.Services.AddScoped<RegistrationService>();
 builder.Services.AddScoped<UserService>();
 builder.Services.AddScoped<FeedbackService>();

--- a/PocketDDD.Server/PocketDDD.Server.WebAPI/UpdateFromSessionizeBackgroundService.cs
+++ b/PocketDDD.Server/PocketDDD.Server.WebAPI/UpdateFromSessionizeBackgroundService.cs
@@ -1,0 +1,37 @@
+﻿using PocketDDD.Server.Services;
+
+namespace PocketDDD.Server.WebAPI;
+
+public class UpdateFromSessionizeBackgroundService(
+    IServiceProvider services,
+    ILogger<UpdateFromSessionizeBackgroundService> logger)
+    : BackgroundService
+{
+    private ILogger<UpdateFromSessionizeBackgroundService> Logger { get; } = logger;
+    private IServiceProvider Services { get; } = services;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        Logger.LogInformation("Update from Sessionize background task started.");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            Logger.LogInformation("About to update from Sessionize.");
+            try
+            {
+                using var scope = Services.CreateScope();
+
+                var sessionizeService = scope.ServiceProvider.GetRequiredService<SessionizeService>();
+                await sessionizeService.UpdateFromSessionize();
+
+                Logger.LogInformation("Update from Sessionize complete.");
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, "Update from Sessionize failed.");
+            }
+            
+            await Task.Delay(TimeSpan.FromMinutes(30), stoppingToken);
+        }
+    }
+}

--- a/PocketDDD.Shared/API/ResponseDTOs/EventDataResponseDTO.cs
+++ b/PocketDDD.Shared/API/ResponseDTOs/EventDataResponseDTO.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace PocketDDD.Shared.API.ResponseDTOs;
 
-namespace PocketDDD.Shared.API.ResponseDTOs;
 public record EventDataResponseDTO
 {
+    public int Id { get; init; }
     public int Version { get; set; }
     public IEnumerable<TimeSlotDTO> TimeSlots { get; set; } = Enumerable.Empty<TimeSlotDTO>();
     public IEnumerable<TrackDTO> Tracks { get; set; } = Enumerable.Empty<TrackDTO>();


### PR DESCRIPTION
- Add logging to Sessionize service
- Run update from Sessionize on startup and then every 30 min as a background service
- Add caching to get event data - set to 5 minutes
- Remove hardcoding that required the event id to always be 1
- Ensure that any changes to event data pulled from sessionize are passed to client apps